### PR TITLE
Use olpz namespace instead of ol

### DIFF
--- a/build/ol3pz.json
+++ b/build/ol3pz.json
@@ -6,7 +6,7 @@
     "externs": [
       "ol3/build/ol-externs.js",
       "ol3/externs/esrijson.js",
-      "externs/olx.js"
+      "externs/olpzx.js"
     ],
     "define": [
       "goog.DEBUG=true"

--- a/examples/black-slider.js
+++ b/examples/black-slider.js
@@ -2,7 +2,7 @@
 var minZoom = 6;
 var maxZoom = 15;
 
-var panZoom = new ol.control.PanZoom({
+var panZoom = new olpz.control.PanZoom({
   imgPath: './resources/zoombar_black',
   minZoom: minZoom,
   maxZoom: maxZoom,

--- a/examples/black.js
+++ b/examples/black.js
@@ -1,4 +1,4 @@
-var panZoom = new ol.control.PanZoom({
+var panZoom = new olpz.control.PanZoom({
   imgPath: './resources/zoombar_black',
   maxExtent: [813079, 5929220, 848966, 5936863]
 });

--- a/examples/custom.js
+++ b/examples/custom.js
@@ -1,4 +1,4 @@
-var panZoom = new ol.control.PanZoom({
+var panZoom = new olpz.control.PanZoom({
   imgPath: './resources/ol2img'
 });
 

--- a/examples/maxextent.js
+++ b/examples/maxextent.js
@@ -1,5 +1,5 @@
 // Define a `maxExtent` to include the "zoom to max extent" button
-var panZoom = new ol.control.PanZoom({
+var panZoom = new olpz.control.PanZoom({
   imgPath: './resources/ol2img',
   maxExtent: [813079, 5929220, 848966, 5936863]
 });

--- a/examples/right.js
+++ b/examples/right.js
@@ -1,4 +1,4 @@
-var panZoom = new ol.control.PanZoom({
+var panZoom = new olpz.control.PanZoom({
   className: 'olControlPanZoomBar', // define a different css class
   imgPath: './resources/ol2img',
   slider: true

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,12 +1,12 @@
 // In OpenLayers 2, the OpenLayers.ImgPath was used to define a directory where
 // native controls fetched their images. The same idea is borrowed here in
 // order to reuse the same images.
-var panZoom = new ol.control.PanZoom({
+var panZoom = new olpz.control.PanZoom({
   imgPath: './resources/ol2img'
 });
 
 var map = new ol.Map({
-  // replace the default `ol.control.Zoom` control by the `ol.control.PanZoom`
+  // replace the default `ol.control.Zoom` control by the `olpz.control.PanZoom`
   controls: ol.control.defaults({
     zoom: false
   }).extend([

--- a/examples/slider.js
+++ b/examples/slider.js
@@ -1,4 +1,4 @@
-var panZoom = new ol.control.PanZoom({
+var panZoom = new olpz.control.PanZoom({
   imgPath: './resources/ol2img',
   slider: true // enables the slider
 });

--- a/externs/olpzx.js
+++ b/externs/olpzx.js
@@ -1,4 +1,16 @@
 /**
+ * @type {Object}
+ */
+var olpzx;
+
+
+/**
+ * @type {Object}
+ */
+olpzx.control;
+
+
+/**
  * @typedef {{
  *     className: (string|undefined),
  *     duration: (number|undefined),
@@ -13,7 +25,7 @@
  * }}
  * @api
  */
-olx.control.PanZoomOptions;
+olpzx.control.PanZoomOptions;
 
 
 /**
@@ -21,7 +33,7 @@ olx.control.PanZoomOptions;
  * @type {string|undefined}
  * @api
  */
-olx.control.PanZoomOptions.prototype.className;
+olpzx.control.PanZoomOptions.prototype.className;
 
 
 /**
@@ -29,7 +41,7 @@ olx.control.PanZoomOptions.prototype.className;
  * @type {number|undefined}
  * @api
  */
-olx.control.PanZoomOptions.prototype.duration;
+olpzx.control.PanZoomOptions.prototype.duration;
 
 
 /**
@@ -37,7 +49,7 @@ olx.control.PanZoomOptions.prototype.duration;
  * @type {string|undefined}
  * @api
  */
-olx.control.PanZoomOptions.prototype.imgPath;
+olpzx.control.PanZoomOptions.prototype.imgPath;
 
 
 /**
@@ -45,7 +57,7 @@ olx.control.PanZoomOptions.prototype.imgPath;
  * @type {ol.Extent|undefined}
  * @api
  */
-olx.control.PanZoomOptions.prototype.maxExtent;
+olpzx.control.PanZoomOptions.prototype.maxExtent;
 
 
 /**
@@ -54,7 +66,7 @@ olx.control.PanZoomOptions.prototype.maxExtent;
  * @type {number|undefined}
  * @api
  */
-olx.control.PanZoomOptions.prototype.maxZoom;
+olpzx.control.PanZoomOptions.prototype.maxZoom;
 
 
 /**
@@ -63,7 +75,7 @@ olx.control.PanZoomOptions.prototype.maxZoom;
  * @type {number|undefined}
  * @api
  */
-olx.control.PanZoomOptions.prototype.minZoom;
+olpzx.control.PanZoomOptions.prototype.minZoom;
 
 
 /**
@@ -71,7 +83,7 @@ olx.control.PanZoomOptions.prototype.minZoom;
  * @type {number|undefined}
  * @api
  */
-olx.control.PanZoomOptions.prototype.pixelDelta;
+olpzx.control.PanZoomOptions.prototype.pixelDelta;
 
 
 /**
@@ -80,7 +92,7 @@ olx.control.PanZoomOptions.prototype.pixelDelta;
  * @type {number|undefined}
  * @api
  */
-olx.control.PanZoomOptions.prototype.slider;
+olpzx.control.PanZoomOptions.prototype.slider;
 
 
 /**
@@ -88,7 +100,7 @@ olx.control.PanZoomOptions.prototype.slider;
  * @type {Element|undefined}
  * @api
  */
-olx.control.PanZoomOptions.prototype.target;
+olpzx.control.PanZoomOptions.prototype.target;
 
 
 /**
@@ -96,4 +108,4 @@ olx.control.PanZoomOptions.prototype.target;
  * @type {number|undefined}
  * @api
  */
-olx.control.PanZoomOptions.prototype.zomDelta;
+olpzx.control.PanZoomOptions.prototype.zomDelta;

--- a/src/ol3panzoom.js
+++ b/src/ol3panzoom.js
@@ -1,19 +1,19 @@
-goog.provide('OL3PanZoom');
+goog.provide('olpz.control.PanZoom');
 
-goog.require('OL3ZoomSlider');
 goog.require('goog.asserts');
 goog.require('goog.events');
 goog.require('goog.events.EventType');
+goog.require('olpz.control.ZoomSlider');
 
 
 
 /**
  * @constructor
- * @param {olx.control.PanZoomOptions=} opt_options Options.
+ * @param {olpzx.control.PanZoomOptions=} opt_options Options.
  * @extends {ol.control.Control}
  * @api
  */
-OL3PanZoom = function(opt_options) {
+olpz.control.PanZoom = function(opt_options) {
 
   var options = opt_options || {};
 
@@ -129,10 +129,10 @@ OL3PanZoom = function(opt_options) {
       this.createButtonEl_('zoom-max') : null;
 
   /**
-   * @type {?OL3ZoomSlider}
+   * @type {?olpz.control.ZoomSlider}
    * @private
    */
-  this.zoomSliderCtrl_ = (this.slider_) ? new OL3ZoomSlider() : null;
+  this.zoomSliderCtrl_ = (this.slider_) ? new olpz.control.ZoomSlider() : null;
 
   element.appendChild(this.panNorthEl_);
   element.appendChild(this.panWestEl_);
@@ -151,20 +151,14 @@ OL3PanZoom = function(opt_options) {
   this.element_ = element;
 
 };
-goog.inherits(OL3PanZoom, ol.control.Control);
-
-
-/**
- * @api
- */
-ol.control.PanZoom = OL3PanZoom;
+goog.inherits(olpz.control.PanZoom, ol.control.Control);
 
 
 /**
  * @param {ol.Map} map
  * @api
  */
-OL3PanZoom.prototype.setMap = function(map) {
+olpz.control.PanZoom.prototype.setMap = function(map) {
 
   var keys = this.listenerKeys_;
   var zoomSlider = this.zoomSliderCtrl_;
@@ -216,7 +210,7 @@ OL3PanZoom.prototype.setMap = function(map) {
  * @return {Element}
  * @private
  */
-OL3PanZoom.prototype.createEl_ = function() {
+olpz.control.PanZoom.prototype.createEl_ = function() {
   var path = this.imgPath_;
   var className = this.className_;
   var cssClasses = [
@@ -246,7 +240,7 @@ OL3PanZoom.prototype.createEl_ = function() {
  * @return {Element}
  * @private
  */
-OL3PanZoom.prototype.createButtonEl_ = function(action) {
+olpz.control.PanZoom.prototype.createButtonEl_ = function(action) {
   var divEl = document.createElement('div');
   var path = this.imgPath_;
   var maxExtent = this.maxExtent_;
@@ -333,7 +327,7 @@ OL3PanZoom.prototype.createButtonEl_ = function(action) {
  * @return {boolean}
  * @private
  */
-OL3PanZoom.prototype.pan_ = function(direction, evt) {
+olpz.control.PanZoom.prototype.pan_ = function(direction, evt) {
   var stopEvent = false;
 
   var map = this.getMap();
@@ -381,7 +375,7 @@ OL3PanZoom.prototype.pan_ = function(direction, evt) {
  * @param {goog.events.BrowserEvent} evt
  * @private
  */
-OL3PanZoom.prototype.zoom_ = function(direction, evt) {
+olpz.control.PanZoom.prototype.zoom_ = function(direction, evt) {
   if (direction === 'in') {
     this.zoomByDelta_(this.zoomDelta_);
   } else if (direction === 'out') {
@@ -402,7 +396,7 @@ OL3PanZoom.prototype.zoom_ = function(direction, evt) {
  * @param {number} delta Zoom delta.
  * @private
  */
-OL3PanZoom.prototype.zoomByDelta_ = function(delta) {
+olpz.control.PanZoom.prototype.zoomByDelta_ = function(delta) {
   var map = this.getMap();
   var view = map.getView();
   if (!view) {
@@ -429,7 +423,7 @@ OL3PanZoom.prototype.zoomByDelta_ = function(delta) {
 /**
  * @private
  */
-OL3PanZoom.prototype.adjustZoomSlider_ = function() {
+olpz.control.PanZoom.prototype.adjustZoomSlider_ = function() {
   var zoomSlider = this.zoomSliderCtrl_;
   var path = this.imgPath_;
 
@@ -466,6 +460,6 @@ OL3PanZoom.prototype.adjustZoomSlider_ = function() {
  * @private
  * @return {number}
  */
-OL3PanZoom.prototype.getSliderSize_ = function() {
+olpz.control.PanZoom.prototype.getSliderSize_ = function() {
   return (this.maxZoom_ - this.minZoom_ + 1) * 11;
 };

--- a/src/zoomslidercontrol.js
+++ b/src/zoomslidercontrol.js
@@ -1,4 +1,4 @@
-goog.provide('OL3ZoomSlider');
+goog.provide('olpz.control.ZoomSlider');
 
 
 
@@ -8,7 +8,7 @@ goog.provide('OL3ZoomSlider');
  * @extends {ol.control.ZoomSlider}
  * @api
  */
-var OL3ZoomSlider = function(opt_options) {
+olpz.control.ZoomSlider = function(opt_options) {
 
   /**
    * @type {Element}
@@ -18,13 +18,13 @@ var OL3ZoomSlider = function(opt_options) {
 
   goog.base(this, opt_options);
 };
-goog.inherits(OL3ZoomSlider, ol.control.ZoomSlider);
+goog.inherits(olpz.control.ZoomSlider, ol.control.ZoomSlider);
 
 
 /**
  * @return {Element}
  * @api
  */
-OL3ZoomSlider.prototype.getElement = function() {
+olpz.control.ZoomSlider.prototype.getElement = function() {
   return this.element;
 };


### PR DESCRIPTION
This library should define a unique namespace for all its components, even if it only has one.  It allows it to be more easily imported in UMD syntax.
