### PR TITLE
Add support for wrapping the build in UMD syntax.

### DIFF
--- a/build/generate-exports.js
+++ b/build/generate-exports.js
@@ -172,6 +172,11 @@ function generateExports(symbols, namespace) {
   Object.keys(requires).sort().reverse().forEach(function(name) {
     blocks.unshift('goog.require(\'' + name + '\');');
   });
+  blocks.unshift(
+      '/**\n' +
+      ' * @fileoverview Custom exports file.\n' +
+      ' * @suppress {checkVars}\n' +
+      ' */\n');
   return blocks.join('\n');
 }
 

--- a/build/ol3pz-debug.json
+++ b/build/ol3pz-debug.json
@@ -1,4 +1,5 @@
 {
   "ignoreRequires": "^ol\\.",
-  "exports": ["*"]
+  "exports": ["*"],
+  "umd": true
 }

--- a/build/ol3pz.json
+++ b/build/ol3pz.json
@@ -1,5 +1,6 @@
 {
   "exports": ["*"],
+  "umd": true,
   "src": ["src/**/*.js"],
   "ignoreRequires": "^ol\\.",
   "compile": {
@@ -53,7 +54,6 @@
     ],
     "compilation_level": "ADVANCED_OPTIMIZATIONS",
     "warning_level": "VERBOSE",
-    "output_wrapper": "(function(){%output%})();",
     "use_types_for_optimization": true,
     "create_source_map": "dist/ol3pz.js.map",
     "source_map_format": "V3"


### PR DESCRIPTION
This is exactly like what was done in ol3, see: https://github.com/openlayers/ol3/commit/b60b0ecdb01de0be7a1e12101cbc74459156dbf0
